### PR TITLE
Fix "There are uncommitted changes" error messages when using mastodon-git with maston (core) 1.0.0-SNAPSHOT-31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,13 @@
 						<configFile>mastodon-coding-style.xml</configFile>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<configuration>
+						<argLine>-Xmx2g</argLine>
+					</configuration>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Matthias Arzt</license.copyrightOwners>
 
-		<mastodon.version>1.0.0-beta-30</mastodon.version>
+		<mastodon.version>1.0.0-beta-31-SNAPSHOT</mastodon.version>
 		<mastodon-tomancak.version>0.4.2</mastodon-tomancak.version>
 		<mastodon-collection.version>1.0.0-beta-26</mastodon-collection.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Matthias Arzt</license.copyrightOwners>
 
-		<mastodon.version>1.0.0-beta-31-SNAPSHOT</mastodon.version>
+		<mastodon.version>1.0.0-beta-30</mastodon.version>
 		<mastodon-tomancak.version>0.4.2</mastodon-tomancak.version>
 		<mastodon-collection.version>1.0.0-beta-26</mastodon-collection.version>
 

--- a/src/main/java/org/mastodon/mamut/collaboration/MastodonGitRepository.java
+++ b/src/main/java/org/mastodon/mamut/collaboration/MastodonGitRepository.java
@@ -78,7 +78,7 @@ public class MastodonGitRepository
 
 	private static final PersistentCredentials credentials = new PersistentCredentials();
 
-	private static final String MASTODON_REMOTE_DATA_FOLDER = "mastodon.remote";
+	private static final String INITIAL_STATE_FOLDER = "mastodon.initial_state";
 
 	private static final String MASTODON_PROJECT_FOLDER = "mastodon.project";
 
@@ -122,13 +122,13 @@ public class MastodonGitRepository
 			throw new MastodonGitException( "The repository already contains a shared mastodon project: " + repositoryURL );
 		Files.createDirectory( mastodonProjectPath );
 
-		Path remoteFolder = directory.toPath().resolve( MASTODON_REMOTE_DATA_FOLDER );
-		if ( Files.exists( remoteFolder ) )
+		final Path initialStateFolder = directory.toPath().resolve( INITIAL_STATE_FOLDER );
+		if ( Files.exists( initialStateFolder ) )
 			throw new MastodonGitException( "The repository already contains a shared mastodon project: " + repositoryURL );
-		Files.createDirectory( remoteFolder );
+		Files.createDirectory( initialStateFolder );
 
 		ProjectSaver.saveProject( mastodonProjectPath.toFile(), projectModel );
-		copyXmlsFromTo( mastodonProjectPath, remoteFolder );
+		copyXmlsFromTo( mastodonProjectPath, initialStateFolder );
 		final Path gitignore = directory.toPath().resolve( ".gitignore" );
 
 		Files.write( gitignore, "/mastodon.project/gui.xml\n".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND );
@@ -136,7 +136,7 @@ public class MastodonGitRepository
 		Files.write( gitignore, "/mastodon.project/dataset.xml.backup\n".getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND );
 		git.add().addFilepattern( ".gitignore" ).call();
 		git.commit().setMessage( "Add .gitignore file" ).call();
-		git.add().addFilepattern( MASTODON_REMOTE_DATA_FOLDER ).addFilepattern( MASTODON_PROJECT_FOLDER ).call();
+		git.add().addFilepattern( INITIAL_STATE_FOLDER ).addFilepattern( MASTODON_PROJECT_FOLDER ).call();
 		git.commit().setMessage( "Share mastodon project" ).call();
 		git.push().setCredentialsProvider( credentials.getSingleUseCredentialsProvider() ).setRemote( "origin" ).call();
 		git.close();
@@ -170,7 +170,7 @@ public class MastodonGitRepository
 				.call())
 		{
 			final Path mastodonProjectPath = directory.toPath().resolve( MASTODON_PROJECT_FOLDER );
-			final Path remoteFolder = directory.toPath().resolve( MASTODON_REMOTE_DATA_FOLDER );
+			final Path remoteFolder = directory.toPath().resolve( INITIAL_STATE_FOLDER );
 			copyXmlsFromTo( remoteFolder, mastodonProjectPath );
 		}
 	}


### PR DESCRIPTION
While using mastodon-git with the latest mastodon 1.0.0-SNAPSHOT-31, a user would often get error messages: ~~that the repository is not clean~~ **"There are uncommitted changes. Please add a save point before pulling"**:

![grafik](https://github.com/user-attachments/assets/bd2299f2-1d6d-428e-b0cd-6d11642173e7) 

The problem also causes the unit tests to fail when using the latest mastodon core dependency.

In version 1.0.0-SNAPSHOT-31 the way Mastodon saves its projects/datasets has been changed, and mastodon-git needs to adapt. If mastodon saves into a folder now the entire old folder is removed. Which resulted in files `project.xml_remote` and other files that where created by mastodon-git in the `mastodon.project` folder are always be removed. Git notices these missing files and reports that as a "repository is not clean" error.

The problem is solved by no longer storing the files "project.xml_remote" etc. in the "mastodon.project/" folder. They are now stored in separate folder "mastodon.remote_data/".

With this changes user should again be able to do all operations mastodon-git provides.

## TODOs
- [ ] delete all test repositories that still use the old "project.xml_remote" files to avoid confusing users
- [x] rename "mastodon.remote" to "mastodon.initial_state"
- [ ] cut a release