### PR TITLE
Change the location of the Mastodon Collaborative (Git) within the Fiji Plugin Menu

### DIFF
--- a/src/main/java/org/mastodon/mamut/collaboration/commands/MastodonGitCloneRepository.java
+++ b/src/main/java/org/mastodon/mamut/collaboration/commands/MastodonGitCloneRepository.java
@@ -43,7 +43,7 @@ import org.scijava.plugin.Plugin;
 // - fill repositoryName with a default value based on the repositoryURL
 @Plugin( type = Command.class,
 		label = "Mastodon Git - Download Shared Project (clone)",
-		menuPath = "Plugins > Mastodon Collaborative (Git) > Download Shared Project" )
+		menuPath = "Plugins > Tracking > Mastodon > Mastodon Collaborative (Git) > Download Shared Project" )
 public class MastodonGitCloneRepository extends AbstractCancellable implements Command
 {
 	@Parameter


### PR DESCRIPTION
This PR changes the location of menu entry within the Fiji Plugin Menu

![grafik](https://github.com/user-attachments/assets/1964b14a-2a3c-452b-8128-d4a12858cc38)

Related to https://github.com/mastodon-sc/mastodon/pull/333